### PR TITLE
Enhance ChatGPT5 Feedback UI with styled box and logo; fix markdown r…

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -111,14 +111,32 @@ window.addEventListener("popstate", () => {
 async function loadMD(path) {
   try {
     if (!path || path.endsWith("index.html")) {
-      path = "./notes/000-welcome.md";
+      path = "./notes/000-welcome.md"; // relative to /docs/
     }
-    const res = await fetch(path + "?v=" + Date.now());
+    // Normalize: ensure starts with ./notes/ or ./pages/
+    if (path.startsWith("notes/")) path = "./" + path;
+    if (path.startsWith("pages/")) path = "./" + path;
+    // Prevent accidental duplication of /docs/
+    if (path.startsWith("docs/notes/")) path = path.replace(/^docs\//, "./");
+    if (path.startsWith("docs/pages/")) path = path.replace(/^docs\//, "./");
+    const fetchPath = path + "?v=" + Date.now();
+    console.log("[loadMD] fetching", fetchPath);
+    const res = await fetch(fetchPath);
+    if (!res.ok) throw new Error(`Fetch failed ${res.status} ${res.statusText} for ${fetchPath}`);
     const text = await res.text();
-    content.innerHTML = marked.parse(text);
+    marked.setOptions({ breaks: true });
+    let html = marked.parse(text);
+    // Post-process to transform paragraphs starting with ChatGPT5 Feedback:
+    const chatgptLogoSVG = '<svg class="chatgpt-logo" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#1890ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.2a4.8 4.8 0 0 1 4.53 3.17 4.8 4.8 0 0 1 5.27 4.71 4.8 4.8 0 0 1-2.84 4.38A4.8 4.8 0 0 1 12 20.8a4.8 4.8 0 0 1-4.53-3.17 4.8 4.8 0 0 1-5.27-4.71 4.8 4.8 0 0 1 2.84-4.38A4.8 4.8 0 0 1 12 3.2Z"/></svg>';
+    html = html.replace(/<p>\s*(?:<em>)?\*?ChatGPT5 Feedback:([\s\S]*?)(?:<\/em>)?<\/p>/gi, (m, body) => {
+      const feedbackText = body.replace(/<\/em>/i, '').trim();
+      return `<div class="chatgpt5-feedback">${chatgptLogoSVG}<span class="chatgpt5-title">ChatGPT5 Feedback:</span> <span class="chatgpt5-text">${feedbackText}</span></div>`;
+    });
+    content.innerHTML = html;
     window.scrollTo({ top: 0, behavior: "smooth" });
   } catch (e) {
-    content.innerHTML = "<p>Unable to load this page.</p>";
+  content.innerHTML = `<p style="color:#b91c1c;background:#fee2e2;padding:12px;border-radius:8px;">Unable to load this page.<br><code>${e.message.replace(/</g,'&lt;')}</code></p>`;
+  console.error(e);
   }
 }
 

--- a/docs/notes/2025-08-29-matthew-5.md
+++ b/docs/notes/2025-08-29-matthew-5.md
@@ -14,37 +14,49 @@ v23–24: God values reconciliation more than my offering to Him. It is like I r
 ## About People
 * **On anger, lust, promises (v21–37)**
  *Question:* When I read Jesus’ teaching on anger (v21–22), lust (v27–28), or promises (v33–37), what do I see about people’s natural tendencies?
+
   *Reflection:* Human beings are sinful by nature. (This is against the Chinese idea “人性本善.” Christianity teaches “人性本恶.”)
+
   *ChatGPT5 Feedback:* This is true, but don’t stop here. Be careful not to only dwell on sinfulness (人性本恶) and forget grace (因信称义). The point is not to condemn you, but to show your need for Christ.
 
 * **On “big sins” vs. “small sins”**
   *Question:* Do I sometimes think I’m doing well spiritually just because I avoid the “big sins,” while ignoring the sins of my thoughts and attitudes?
+
   *Reflection:* I never treat sin as small. I know no sin is too small, but even though I know the truth, I still commit sins.
+
   *ChatGPT5 Feedback:* Good humility. But be careful not to get stuck in guilt. Always look back to the cross. Romans 8:1 reminds us there is no condemnation in Christ.
 
 * **On righteousness**
   *Question:* Why do people tend to lower the standard of righteousness to what feels manageable, instead of God’s higher standard?
+
   *Reflection:* People don’t see *why* they should follow God’s higher standard. On earth there are too many distractions. People pursue enjoyment, good food, and a good life. Righteousness is not the priority.
+
   *ChatGPT5 FeedbackFeedback:* Very true observation. Let this remind you: if righteousness isn’t first, everything else will easily distract the heart.
 
 ## To Christ
 * **Jesus as Teacher**
   *Question:* What does this chapter reveal about how Jesus teaches and what He cares about most?
+  
   *Reflection:* Jesus points beyond the rules to the heart. He foresaw human feelings and the world’s values. Like saying, “I know many people are telling you this, or this is what the world promotes… but I tell you the truth.”
 
 ## Application
-**Reconciliation (v23–24)**
+* **Reconciliation (v23–24)**
    *Question:* Is there a specific relationship right now where reconciliation is more urgent than just “doing my spiritual duties”?
+
    *Reflection:* Yes, there are at least five relationships. But my heart is reluctant, because it requires a lot of effort, and right now I feel drained as I rush my work project deadlines.
+   
    *ChatGPT5 Feedback:* This is where your heart might drift. Jesus clearly teaches reconciliation is urgent, even above worship. Work deadlines can’t be your reason to delay obedience. Start with one small step — don’t try to fix all at once.
    
-**One teaching to practice this week**
+* **One teaching to practice this week**
    *Question:* Which one teaching from this sermon do I want to intentionally practice this week?
+
    *Reflection:* I will focus on anger (v22). Specifically, I will try to control my anger when driving on the road, out of obedience to God.
+
    *ChatGPT5 Feedback:* Very practical. But don’t only suppress anger externally — invite God to transform the root of anger in your heart.
 
 ## Open Questions
 * There are so many good and important teachings in the Bible. How can I make sure I obey all of them and strive for perfection? What are the practical steps? (v48)
+
   *ChatGPT5 Feedback:* Be careful here. The call to perfection is not about you achieving it all at once. It is about abiding in Christ, step by step, and letting His Spirit transform you.
 
 ## Personal Experiences

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,30 @@
+/* ChatGPT5 Feedback Box */
+.chatgpt5-feedback {
+  background: #e6f7ff;
+  border-left: 4px solid #1890ff;
+  padding: 12px 16px;
+  margin: 18px 0;
+  display: flex;
+  align-items: flex-start;
+  font-family: 'Segoe UI', Arial, sans-serif;
+  box-shadow: 0 2px 8px rgba(24,144,255,0.08);
+  border-radius: 8px;
+}
+.chatgpt-logo {
+  width: 28px;
+  height: 28px;
+  margin-right: 12px;
+  flex-shrink: 0;
+}
+.chatgpt5-title {
+  font-weight: bold;
+  color: #1890ff;
+  margin-right: 8px;
+}
+.chatgpt5-text {
+  font-style: italic;
+  color: #333;
+}
 
 :root {
   --bg: #ffffff;


### PR DESCRIPTION
**UX Improvements**
* Added post-processing in `docs/app.js` to detect paragraphs starting with "ChatGPT5 Feedback:" and transform them into styled feedback boxes with a ChatGPT logo in the rendered HTML.
* Introduced new CSS styles in `docs/style.css` for `.chatgpt5-feedback`, `.chatgpt-logo`, `.chatgpt5-title`, and `.chatgpt5-text` to visually distinguish feedback sections.